### PR TITLE
Add support for --token-usage/-t flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Feel free to run the program multiple times to get the best result!
 - `-o`, `--output` : Specify an output file
 - `-h`, `--help` : Print help
 - `-V`, `--version` : Print version
+- `-t`, `--token-usage` : Print token usage
 
 ## 🛠️ Building
 

--- a/src/api/chat_completions.rs
+++ b/src/api/chat_completions.rs
@@ -1,7 +1,9 @@
-use super::json_models::chat_completion::{ChatCompletionResponse, Usage};
+use super::json_models::chat_completion::{ChatCompletionResponse};
 use super::Instance;
 use crate::clue::ClueCollection;
 use serde_json::json;
+
+
 
 const SYSTEM_PROMPT: &str = r#"
 You are the spymaster in Codenames.
@@ -25,7 +27,7 @@ impl Instance {
         &self,
         link_words: Vec<String>,
         avoid_words: Vec<String>,
-    ) -> Result<(ClueCollection, Usage), Box<dyn std::error::Error>> {
+    ) -> Result<ClueCollection, Box<dyn std::error::Error>> {
         let request_body = self.build_request_body(link_words, avoid_words);
 
         // Get response from API endpoint
@@ -44,7 +46,8 @@ impl Instance {
             .map_err(|_| "Failed to parse clues from API server")?;
 
         // Extract usage information from the parsed response
-        let usage = parsed_response.usage.clone();
+        let token_usage = parsed_response.usage;
+
 
         // Extract clue strings from the parsed response
         let clue_strings = parsed_response
@@ -58,9 +61,9 @@ impl Instance {
             .collect::<Vec<String>>();
 
         // Build clues
-        let clue_collection = ClueCollection::new(clue_strings);
+        let clue_collection = ClueCollection::new(clue_strings, token_usage);
 
-        Ok((clue_collection, usage))
+        Ok(clue_collection)
     }
 
     fn build_request_body(

--- a/src/api/json_models/chat_completion.rs
+++ b/src/api/json_models/chat_completion.rs
@@ -10,7 +10,7 @@ pub struct Choice {
     pub message: Message,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,

--- a/src/api/json_models/chat_completion.rs
+++ b/src/api/json_models/chat_completion.rs
@@ -10,7 +10,15 @@ pub struct Choice {
     pub message: Message,
 }
 
+#[derive(Deserialize, Clone)]
+pub struct Usage {
+    pub prompt_tokens: usize,
+    pub completion_tokens: usize,
+    pub total_tokens: usize,
+}
+
 #[derive(Deserialize)]
 pub struct ChatCompletionResponse {
     pub choices: Vec<Choice>,
+    pub usage: Usage,
 }

--- a/src/api/json_models/mod.rs
+++ b/src/api/json_models/mod.rs
@@ -1,2 +1,2 @@
-pub mod chat_completion;
 pub mod language_model;
+pub mod chat_completion;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,5 @@
-mod chat_completions;
-mod json_models;
+pub mod chat_completions;
+pub mod json_models;
 mod language_models;
 
 use dotenv::dotenv;

--- a/src/clue.rs
+++ b/src/clue.rs
@@ -1,7 +1,7 @@
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Table};
-
+use crate::api::json_models::chat_completion::Usage;
 struct Clue {
     clue_word: String,
     count: usize,
@@ -10,12 +10,15 @@ struct Clue {
 
 pub struct ClueCollection {
     clues: Vec<Clue>,
+    pub usage: Usage,
 }
 
 impl Clue {
     /// Create a new instance of `Clue` from a single line of clue responses from the API
     pub fn new(clue_line: &str) -> Option<Self> {
         let chunks: Vec<&str> = clue_line.split(", ").collect();
+
+
 
         // Discard empty lines as well as clues with only one word linked
         if chunks.len() < 4 {
@@ -44,13 +47,13 @@ impl Clue {
 
 impl ClueCollection {
     /// Create an instance of `ClueCollection` from `Vec<String>`, which contains lines of clue response from the API
-    pub fn new(clue_strings: Vec<String>) -> Self {
+    pub fn new(clue_strings: Vec<String>, usage: Usage) -> Self {
         let mut clues: Vec<Clue> = clue_strings.iter().filter_map(|s| Clue::new(s)).collect();
 
         // Sort the clues by the number of words they link together
         clues.sort_by(|a, b| b.count.cmp(&a.count));
 
-        Self { clues }
+        Self { clues, usage }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ pub struct Args {
     #[arg(short, long, value_name = "FILE")]
     pub output: Option<PathBuf>,
 
+    /// Print all token usage information
+    #[arg(short, long = "token-usage")]
+    pub token: bool,
+
     /// File containing words to link together - the words from your team
     #[arg(required_unless_present = "get")]
     pub to_link: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@ use clap::Parser;
 use mastermind::api::Instance;
 use mastermind::*;
 
-use std::io::{self, Write};
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Read arguments and environment variables
@@ -29,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let avoid_words = read_words_from_file(args.to_avoid.unwrap())?;
 
     // Get clues from API
-    let (clue_collection, usage) = api_instance
+    let clue_collection = api_instance
         .fetch_clue_collection(link_words, avoid_words)
         .await?;
 
@@ -47,11 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // If -t is set, output the token usage information
     if args.token {
         // Write to stderr in the format: prompt_tokens, completion_tokens, total_tokens
-        writeln!(
-            io::stderr(),
-            "\nTokens Usage\n----------------------\nPrompt Tokens: {}\nCompletion Tokens: {}\n----------------------\nTotal Tokens: {}",
-            usage.prompt_tokens, usage.completion_tokens, usage.total_tokens
-        )?;
+        eprintln!("\nTokens Usage\n----------------------\nPrompt Tokens: {}\nCompletion Tokens: {}\n----------------------\nTotal Tokens: {}",
+                  clue_collection.usage.prompt_tokens, clue_collection.usage.completion_tokens, clue_collection.usage.total_tokens);
     }
 
     Ok(())


### PR DESCRIPTION
This pull request implements/ fixes issue #11

 ## What changed
 
 - Function `fetch_clue_collection()` now returns additional object `Usage`, instead of just `ClueCollection`
- Added public structure called `Usage` that is being passed to `ChatCompletionResponse`
- Added ability of usage of t/--token-usage flags
- Updated main.rs to output the `token usage` to `stderr`
- Updated README.md documentation 
    