### PR TITLE
Unit test test_build_request_body() added

### DIFF
--- a/src/api/chat_completions.rs
+++ b/src/api/chat_completions.rs
@@ -77,10 +77,10 @@ impl Instance {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use super::*;
-    use httpmock::prelude::*;
     use crate::read_words_from_file;
+    use httpmock::prelude::*;
+    use std::path::PathBuf;
 
     #[tokio::test]
     async fn test_post_chat_completions() {

--- a/src/api/chat_completions.rs
+++ b/src/api/chat_completions.rs
@@ -77,8 +77,10 @@ impl Instance {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use super::*;
     use httpmock::prelude::*;
+    use crate::read_words_from_file;
 
     #[tokio::test]
     async fn test_post_chat_completions() {
@@ -103,5 +105,40 @@ mod tests {
             .await
             .unwrap();
         mock.assert();
+    }
+
+    #[test]
+    fn test_build_request_body() {
+        // Mock input data
+        let link_words = vec!["link1".to_string(), "link2".to_string()];
+        let avoid_words = vec!["avoid1".to_string(), "avoid2".to_string()];
+        let model_id = "model".to_string();
+
+        // Assign result to the result of build_request_body() method
+        let result = Instance::build_request_body(&link_words, &avoid_words, &model_id);
+
+        // Format expected content
+        let expected_content = format!(
+            "To Link:\n{}\n\nTo Avoid:\n{}",
+            link_words.join("\n"),
+            avoid_words.join("\n")
+        );
+
+        // Mock expected output
+        let expected = json!(
+            {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": SYSTEM_PROMPT,
+                },
+                {
+                    "role": "user",
+                    "content": expected_content
+                }
+            ],
+            "model": model_id
+        });
+        assert_eq!(expected, result);
     }
 }


### PR DESCRIPTION
Closes #21 

## Description 

Unit test for build_request_body() added by mocking expected output and passing arguments to the tested function inside of `api/chat_completions.rs`

Test gets passed:

<img width="535" alt="image" src="https://github.com/user-attachments/assets/f0d18ab6-1f68-4568-93c6-d15d410e65fb">

If you have doubts or questions, feel free to ask!